### PR TITLE
Add Mention function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DISCORD_WEBHOOK_URL="YOUR_DISCORD_WEBHOOK_URL"
+DISCORD_MENTION_ENABLED="false"
 TARGET_PREFECTURES="Tokyo"
 # Multiple designations are possible by using ","

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,12 +6,14 @@ dotenv.config();
 interface Env {
   NODE_ENV?: string;
   DISCORD_WEBHOOK_URL?: string;
+  DISCORD_MENTION_ENABLED: boolean;
   TARGET_PREFECTURES?: string;
 }
 
 const env: Env = {
   NODE_ENV: process.env.NODE_ENV,
   DISCORD_WEBHOOK_URL: process.env.DISCORD_WEBHOOK_URL,
+  DISCORD_MENTION_ENABLED: process.env.DISCORD_MENTION_ENABLED === 'true',
   TARGET_PREFECTURES: process.env.TARGET_PREFECTURES,
 };
 

--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -61,6 +61,7 @@ export default async function sendMessage(body: Body): Promise<void> {
 
     // Data to be sent to Webhook
     const payload = JSON.stringify({
+      ...(env.DISCORD_MENTION_ENABLED && { content: '@everyone' }),
       embeds: [body],
     });
 


### PR DESCRIPTION
## Overview

We have made it possible to enable or disable the `@everyone` mention using environment variables.

### Changes Made

- Added the environment variable `DISCORD_MENTION_ENABLED`.
- Modified the system to create the `content` of the message to be sent based on the environment variable.

### Issues Resolved

You can efficiently send notifications to the members participating.

## Checklist

- [x] The code follows the style guide.
- [x] Tests have been run and all tests have passed.
- [x] Documentation has been updated where necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable to control Discord mentions.
	- Enhanced message sending functionality to include mentions based on the new configuration.

- **Bug Fixes**
	- No specific bug fixes were included in this release.

- **Documentation**
	- Updated `.env.example` to reflect the new environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->