### PR TITLE
Add a feature to post messages to multiple channels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,16 @@ const isDev: boolean = NODE_ENV === 'development';
 const RECONNECT_DELAY: number = 5000; // 5 seconds
 let isFirstRun = true; // Flag to check if it's the initial run
 
-if (
-  env.DISCORD_WEBHOOK_URL === undefined ||
-  !env.DISCORD_WEBHOOK_URL.startsWith('https://discord.com/api/webhooks/')
-) {
-  console.error('DISCORD_WEBHOOK_URL is not set or invalid.');
+if (env.DISCORD_WEBHOOK_URL !== undefined) {
+  const webhookUrls = env.DISCORD_WEBHOOK_URL.split(',');
+  for (const url of webhookUrls) {
+    if (!String(url).startsWith('https://discord.com/api/webhooks/')) {
+      console.error('DISCORD_WEBHOOK_URL is not set or invalid.');
+      process.exit(1);
+    }
+  }
+} else {
+  console.error('DISCORD_WEBHOOK_URL is not set.');
   process.exit(1);
 }
 

--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -24,13 +24,20 @@ export default async function sendMessage(body: Body): Promise<void> {
     }
   }
 
+  const webhookUrls = env.DISCORD_WEBHOOK_URL.split(',');
+  for (const url of webhookUrls) {
+    await sendWebhook(body, url);
+  }
+}
+
+async function sendWebhook(body: Body, url: string): Promise<void> {
   try {
-    const url = new URL(env.DISCORD_WEBHOOK_URL);
+    const newUrl = new URL(url);
 
     // Setting options for POST data
     const options = {
-      hostname: url.hostname,
-      path: url.pathname,
+      hostname: newUrl.hostname,
+      path: newUrl.pathname,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Overview

The Webhook URL, which could previously only specify one, can now be specified for multiple URLs.

### Changes Made

You can now specify multiple Discord Webhooks for different channels in the environment variable using commas

### Issues Resolved

This eliminates the need to start and manage multiple containers.

## Checklist

- [x] The code follows the style guide.
- [x] Tests have been run and all tests have passed.
- [x] Documentation has been updated where necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for sending messages to multiple Discord webhook URLs.
	- Introduced a new function for sending messages to individual webhook URLs.

- **Bug Fixes**
	- Improved error handling for webhook URL validation and message sending processes.

- **Documentation**
	- Updated logging statements for better clarity on success and failure of webhook message sending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->