### PR TITLE
Change Webhook to log the success count

### DIFF
--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -32,7 +32,7 @@ export default async function sendMessage(body: Body): Promise<void> {
     if (success) {
       successCount++;
     } else {
-      console.error(`Failed to send webhook to ${url}`);
+      console.error(`Failed to send webhook: ${url}`);
     }
   }
 

--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -87,8 +87,14 @@ async function sendWebhook(body: Body, url: string): Promise<boolean> {
       });
 
       // Write data to request
-      req.write(payload);
-      req.end();
+      try {
+        req.write(payload);
+        req.end();
+      } catch (writeError) {
+        console.error('Error writing to request:', writeError);
+        req.destroy();
+        resolve(false);
+      }
     } catch (webhookError) {
       console.error('Error during webhook message send:', webhookError);
       resolve(false);

--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -25,59 +25,72 @@ export default async function sendMessage(body: Body): Promise<void> {
   }
 
   const webhookUrls = env.DISCORD_WEBHOOK_URL.split(',');
+  let successCount = 0;
+
   for (const url of webhookUrls) {
-    await sendWebhook(body, url);
+    const success = await sendWebhook(body, url);
+    if (success) {
+      successCount++;
+    } else {
+      console.error(`Failed to send webhook to ${url}`);
+    }
   }
+
+  // Log the number of successful webhooks
+  console.info(`Webhook sent (${successCount}/${webhookUrls.length})`);
 }
 
-async function sendWebhook(body: Body, url: string): Promise<void> {
-  try {
-    const newUrl = new URL(url);
+async function sendWebhook(body: Body, url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const newUrl = new URL(url);
 
-    // Setting options for POST data
-    const options = {
-      hostname: newUrl.hostname,
-      path: newUrl.pathname,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      timeout: 10000,
-    };
+      // Setting options for POST data
+      const options = {
+        hostname: newUrl.hostname,
+        path: newUrl.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        timeout: 10000,
+      };
 
-    // Create a request
-    const req = https.request(options, (res) => {
-      if (res.statusCode !== undefined && res.statusCode >= 400) {
-        console.error(`Webhook error: ${res.statusCode}`);
-        return;
-      }
+      // Create a request
+      const req = https.request(options, (res) => {
+        if (res.statusCode !== undefined && res.statusCode >= 400) {
+          console.error(`Webhook error: ${res.statusCode}`);
+          resolve(false);
+          return;
+        }
 
-      let data = '';
-      res.on('data', (chunk) => {
-        data += chunk;
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+
+        res.on('end', () => {
+          resolve(true);
+        });
       });
 
-      res.on('end', () => {
-        console.info(`Webhook success: ${res.statusCode}`);
+      req.on('error', (e) => {
+        console.error(`Error during webhook message send: ${e.message}`);
+        resolve(false);
       });
-    });
 
-    req.on('error', (e) => {
-      console.error(`Error during webhook message send: ${e.message}`);
-    });
+      // Data to be sent to Webhook
+      const payload = JSON.stringify({
+        ...(env.DISCORD_MENTION_ENABLED && { content: '@everyone' }),
+        embeds: [body],
+      });
 
-    // Data to be sent to Webhook
-    const payload = JSON.stringify({
-      ...(env.DISCORD_MENTION_ENABLED && { content: '@everyone' }),
-      embeds: [body],
-    });
-
-    // Write data to request
-    req.write(payload);
-    req.end();
-
-    console.info('Message successfully sent to webhook');
-  } catch (webhookError) {
-    console.error('Error during webhook message send:', webhookError);
-  }
+      // Write data to request
+      req.write(payload);
+      req.end();
+    } catch (webhookError) {
+      console.error('Error during webhook message send:', webhookError);
+      resolve(false);
+    }
+  });
 }

--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -76,6 +76,7 @@ async function sendWebhook(body: Body, url: string): Promise<boolean> {
 
       req.on('error', (e) => {
         console.error(`Error during webhook message send: ${e.message}`);
+        req.destroy();
         resolve(false);
       });
 


### PR DESCRIPTION
## Overview

Previously, a log was output for each request to the Discord Webhook, but with this change, the number of successful requests is now displayed in a format like `(1/2)`.

### Changes Made

Modify `sendWebhook` in `send.ts` to return `true` on success, `false` on failure, increment `successCount` for each success, and log the final count as `(success/total)`.

### Issues Resolved

Resolve the issue of cluttered logs making debugging difficult.

## Checklist

- [x] The code follows the style guide.
- [x] Tests have been run and all tests have passed.
- [x] Documentation has been updated where necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for webhook sending.
	- Introduced tracking for successful webhook sends.

- **Bug Fixes**
	- Improved control flow for webhook requests to ensure better reliability.
	- Updated logging to report total successful webhook sends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->